### PR TITLE
Add WSS/HTTPS support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,6 @@ name: Build
 
 on:
     push:
-        branches-ignore: ['main']
         tags-ignore:
             - 'v*'
     pull_request:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,14 @@
 name: Publish to npm
 
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish, without v prefix (for example 1.3.3 or 1.4.0-beta.0)'
+        required: true
 
 jobs:
   publish:
@@ -30,9 +36,11 @@ jobs:
       - name: Extract version from release
         id: get_version
         run: |
-          # Extract version from tag name (remove 'v' prefix if present)
-          VERSION=${GITHUB_REF#refs/tags/}
-          VERSION=${VERSION#v}
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ github.event.inputs.version }}"
+          else
+            VERSION="${GITHUB_REF_NAME#v}"
+          fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Extracted version: $VERSION"
 
@@ -52,25 +60,19 @@ jobs:
         id: determine_dist_tag
         run: |
           # Determine dist tag for npm publish.
-          # If the GitHub release is marked as prerelease, try to use the pre-release identifier
+          # If the version has a pre-release identifier, use it as dist-tag
           # (e.g. v1.2.3-alpha.1 => tag "alpha"). Otherwise use "latest".
-          # As a fallback for prerelease without a suffix use "next".
-          VERSION=${GITHUB_REF#refs/tags/}
-          VERSION=${VERSION#v}
+          VERSION="${{ steps.get_version.outputs.version }}"
 
-          if [ "${{ github.event.release.prerelease }}" = "true" ]; then
-            if [[ "$VERSION" == *"-"* ]]; then
-              PR=${VERSION#*-}
-              LABEL=${PR%%.*}
-              echo "dist_tag=$LABEL" >> $GITHUB_OUTPUT
-            else
-              echo "dist_tag=next" >> $GITHUB_OUTPUT
-            fi
+          if [[ "$VERSION" == *"-"* ]]; then
+            PR=${VERSION#*-}
+            LABEL=${PR%%.*}
+            echo "dist_tag=$LABEL" >> $GITHUB_OUTPUT
           else
             echo "dist_tag=latest" >> $GITHUB_OUTPUT
           fi
 
       - name: Publish to npm
-        run: npm publish --tag ${{ steps.determine_dist_tag.outputs.dist_tag }}
+        run: npm publish --access public --tag ${{ steps.determine_dist_tag.outputs.dist_tag }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# loxone-ts-api
+# @rudyberends/loxone-ts-api
 A Node module written in TypeScript for facilitating communication with Loxone Miniservers. Communication is done using http and WebSockets.
 
-## Key featrues
+## Key features
 
 - Connects to the Loxone Miniserver via WebSocket
   - Support for both Gen.1 and Gen.2 Miniservers
@@ -48,7 +48,7 @@ Uses token authentication with the Miniserver. Automatically attempts token refr
 
 ```ts
 import { AnsiLogger, LogLevel, TimestampFormat } from "node-ansi-logger";
-import LoxoneClient from "./LoxoneClient.js";
+import LoxoneClient from "@rudyberends/loxone-ts-api";
 
 let log = new AnsiLogger({logName: "workbench", logTimestampFormat: TimestampFormat.TIME_MILLIS});
 
@@ -92,7 +92,7 @@ client.on('event_value', (event) => {
 });
 
 // initiates streaming of events
-await client.enablesUpdates(); 
+await client.enableUpdates();
 
 // disconnects and kills token
 await client.disconnect(); 
@@ -123,6 +123,7 @@ Key entrypoint to the module.
         host: string,
         username: string,
         password: string,
+        useTls: boolean,
         clientOptions: Partial<LoxoneClientOptions>
     )
 ```
@@ -134,6 +135,7 @@ Key entrypoint to the module.
 |host|IP address or hostname of the Loxone Miniserver|
 |username|username to use|
 |password|password for the user|
+|useTls|optional boolean to connect through HTTPS/WSS instead of HTTP/WS|
 |clientOptions.autoReconnectEnabled|optional parameter to override the default behavior of automatically reconnecting on failure/disconnection|
 |clientOptions.keepAliveEnabled|optional parameter to override the default behavior of enabling a 15 second keepalive
 |clientOptions.messageLogEnabled|optional parameter to override the default behavior of enabling a logging of messages and responses

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # loxone-ts-api
 A Node module written in TypeScript for facilitating communication with Loxone Miniservers. Communication is done using http and WebSockets.
 
-Currently only implemented http/ws communication to enable support for Gen.1 and Gen.2 Miniservers. https/wss communication currently not supported, but planned.
-
 ## Key featrues
 
 - Connects to the Loxone Miniserver via WebSocket

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "loxone-ts-api",
+  "name": "@rudyberends/loxone-ts-api",
   "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "loxone-ts-api",
+      "name": "@rudyberends/loxone-ts-api",
       "version": "1.3.2",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,19 @@
 {
-  "name": "loxone-ts-api",
+  "name": "@rudyberends/loxone-ts-api",
   "version": "1.3.2",
   "description": "TypeScript client for the Loxone API",
   "type": "module",
   "main": "dist/LoxoneClient.js",
   "types": "dist/LoxoneClient.d.ts",
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "clean": "rm -rf dist",
     "build": "npm run clean && tsc -p .",
+    "prepack": "npm run build",
     "typecheck": "tsc -p . --noEmit",
     "start": "node dist/workbench.js",
     "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx,json,css,md}\"",
@@ -17,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/andrasg/loxone-ts-api.git"
+    "url": "git+https://github.com/rudyberends/loxone-ts-api.git"
   },
   "keywords": [
     "loxone",

--- a/src/Services/Auth.ts
+++ b/src/Services/Auth.ts
@@ -8,6 +8,7 @@ class Auth {
     private password: string;
     private username: string;
     private host: string;
+    private useTls: boolean;
     private connection: WebSocketConnection;
     private publicKey: { key: string; padding: number } | undefined;
     private sessionKey: string | undefined;
@@ -18,12 +19,13 @@ class Auth {
     commandEncryption: CommandEncryption;
     log: AnsiLogger;
 
-    constructor(log: AnsiLogger, connection: WebSocketConnection, host: string, username: string, password: string) {
+    constructor(log: AnsiLogger, connection: WebSocketConnection, host: string, username: string, password: string, useTls: boolean) {
         this.log = log;
         this.connection = connection;
         this.host = host;
         this.username = username;
         this.password = password;
+        this.useTls = useTls;
 
         this.tokenHandler = new TokenHandler(this, log, this.connection, this.username, this.password);
         this.commandEncryption = new CommandEncryption(this);
@@ -66,7 +68,9 @@ class Auth {
     }
 
     private async getPublicKey() {
-        const response = await fetch('http://' + this.host + '/jdev/sys/getcertificate');
+        const protocol = this.useTls ? 'https' : 'http';
+        const url = `${protocol}://${this.host}/jdev/sys/getcertificate`;
+        const response = await fetch(url);
         this.parsePublicKey(await response.text());
     }
 

--- a/src/Services/WebSocketConnection.ts
+++ b/src/Services/WebSocketConnection.ts
@@ -30,6 +30,7 @@ class WebSocketConnection extends EventEmitter {
     private nextExpectedMessageType: MessageType = MessageType.HEADER;
     private ws: WebSocket | undefined;
     private host: string;
+    private useTls: boolean;
     private loxoneClient: LoxoneClient;
 
     // keepalive handling
@@ -47,17 +48,20 @@ class WebSocketConnection extends EventEmitter {
     private log: AnsiLogger;
     private messageLog: boolean;
 
-    constructor(loxoneClient: LoxoneClient, log: AnsiLogger, host: string, commandTimeout: number, messageLog: boolean) {
+    constructor(loxoneClient: LoxoneClient, log: AnsiLogger, host: string, useTls: boolean, commandTimeout: number, messageLog: boolean) {
         super();
         this.loxoneClient = loxoneClient;
         this.host = host;
+        this.useTls = useTls;
         this.COMMAND_TIMEOUT = commandTimeout;
         this.log = log;
         this.messageLog = messageLog;
     }
 
     async connect() {
-        this.ws = new WebSocket(`ws://${this.host}/ws/rfc6455`, 'remotecontrol');
+        const protocol = this.useTls ? 'wss' : 'ws';
+        const url = `${protocol}://${this.host}/ws/rfc6455`;
+        this.ws = new WebSocket(url, 'remotecontrol');
         this.ws.on('open', () => {
             this.emit('connected');
         });

--- a/testclient.js
+++ b/testclient.js
@@ -1,0 +1,35 @@
+import LoxoneClient from './dist/LoxoneClient.js';
+
+// instantiate the client
+const client = new LoxoneClient('168-119-185-175.504f94a10e9b.dyndns.loxonecloud.com:51064', 'web', 'web', true, {
+    messageLogEnabled: true,
+});
+
+// sets log level to debug for more verbose logging
+// client.setLogLevel(LogLevel.DEBUG);
+
+// subscribe to basic events
+client.on('disconnected', () => {
+    console.log('Loxone client disconnected');
+});
+client.on('error', (error) => {
+    console.log(`Loxone client error: ${error.message}`, error);
+});
+
+// initiate connection
+await client.connect();
+
+await client.parseStructureFile();
+
+// subscribe to Loxone value updates
+client.on('event_value', (event) => {
+    console.log(`Received value event: ${event.uuid.stringValue}`);
+    console.log(`  Room: ${event.state?.parentControl?.room?.name}`);
+    console.log(`  Control: ${event.state?.parentControl?.name}`);
+    console.log(`  State: ${event.state?.name}`);
+    console.log(`  Event path: ${event.toPath()}`);
+    // console.log(`  Full event: ${event.toString()}`);
+});
+
+// initiates streaming of events
+await client.enableUpdates();

--- a/testclient.js
+++ b/testclient.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import LoxoneClient from './dist/LoxoneClient.js';
 
 // instantiate the client


### PR DESCRIPTION
This PR adds full WSS/HTTPS support to the LoxoneClient while preserving the existing API.

In this version, loxoneclient accepts an additional parameter to use TLS. This will use HTTPS/WSS for communication. Parameter will default to false if it is not passed.

new LoxoneClient(host, username, password, **true**, { logLevel: LogLevel.Debug });

original syntax will still work.
new LoxoneClient(host, username, password, { logLevel: LogLevel.Debug });

