### PR TITLE
docs: fix enableUpdates typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ client.on('event_value', (event) => {
 });
 
 // initiates streaming of events
-await client.enablesUpdates(); 
+await client.enableUpdates(); 
 
 // disconnects and kills token
 await client.disconnect(); 


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Summary
- Correct the README example call from `enablesUpdates()` to `enableUpdates()`.

Fixes #18

## Test plan
- static validation: `enablesUpdates` appeared 1 time(s) in `README.md` before replacement.
- static validation: `enableUpdates` is present in `README.md` after patch.
- static validation: `enablesUpdates` is absent from `README.md` after patch.
- Not run: runtime test suite, because this is a small README/documentation typo fix.
